### PR TITLE
Dockerfile update: OS changed to baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
-FROM mhart/alpine-node:latest
+# Use phusion/baseimage as base image. To make your builds reproducible, make
+# sure you lock down to a specific version, not to `latest`!
+# See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
+# a list of version numbers.
+FROM phusion/baseimage:0.11
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# ...put your own build instructions here... #
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 RUN mkdir -p /app
 WORKDIR /app
 COPY . /app
 
 # @todo: Verify that this build process is not producing any bugs!
-
-# --no-cache: download package index on-the-fly, no need to cleanup afterwards
-# --virtual: bundle packages, remove whole bundle at once, when done
-RUN apk --no-cache --virtual build-dependencies add \
-    bash \
-    ruby \
-    ruby-irb \
-    python \
+RUN install_clean \
     make \
     g++ \
+    ruby \
+    npm \
+    nodejs \
+    python \
     && npm install \
     && npm run build
-    # && apk del build-dependencies
 
 EXPOSE 3000
 
 # Uncomment for regular server.
-# CMD ["node", "server.js"]
+CMD ["node", "server.js"]
 
 # Uncomment for debugging/logs.
-CMD [ "npm", "run", "debug" ]
+# CMD [ "npm", "run", "debug" ]
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+#   Clean up APT when done.    #
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The previous hanging bug [commit 14ad8961b1afc04fcabc806be6323c0314acac61] was due to Alpine Linux running as the OS within the container. This is solved by switching to baseimage-docker.
One possible reason the bug happened that some important services may not run automatically, as well as zombie processes filling up due to the improper starting of the 'init' process. Further info can be found at: http://phusion.github.io/baseimage-docker/