### PR TITLE
Modify Output Cache Handling - Performance Optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2802,7 +2802,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2813,7 +2814,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2930,7 +2932,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2942,6 +2945,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2964,12 +2968,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2988,6 +2994,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3068,7 +3075,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3080,6 +3088,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3201,6 +3210,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const TOO_MUCH_OUTPUT = (() => {
   return Ansi.cursorUp(1) + formatted + Ansi.cursorDown(1) + Ansi.cursorBackward(text.length)
 })()
 const MAX_OUTPUT_LENGTH = 10000
-const MAX_HIST_LENGTH = 1000000
+const MAX_HIST_LENGTH = 100000
 const DEFAULT_LANG = 'ruby'
 
 io.on('connection', (socket) => {


### PR DESCRIPTION
- place `io.emit('output', { output })` before caching to avoid processing time before output (performance optimization)
- Modify `TOO_MUCH_OUTPUT` for better visual
- add `currOutputLength` variable to keep track of the current output length in between evaluations
- Add `MAX_HIST_LENGTH` to limit historical output to 100,000 characters, and reset `histOutput` to last 1000 characters if exceeded