### PR TITLE
change url to '/' to fix reverse proxy bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
 # a list of version numbers.
 FROM phusion/baseimage:0.11
+RUN useradd -ms /bin/false newuser
 
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
@@ -27,6 +28,7 @@ RUN install_clean \
 
 EXPOSE 3000
 
+USER newuser
 # Uncomment for regular server.
 CMD ["node", "server.js"]
 
@@ -36,4 +38,5 @@ CMD ["node", "server.js"]
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   Clean up APT when done.    #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# USER root                    # If this is run, user assumes root within the application
+# RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -2780,14 +2780,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2802,20 +2800,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2932,8 +2927,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2945,7 +2939,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2960,7 +2953,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2968,14 +2960,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2994,7 +2984,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3075,8 +3064,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3088,7 +3076,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3210,7 +3197,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4718,6 +4704,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-libs-browser": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "codemirror-one-dark-theme": "^1.1.1",
     "debug": "^4.1.0",
     "express": "^4.16.4",
+    "node-fetch": "^2.3.0",
     "node-pty": "^0.7.8",
     "socket.io": "^2.1.1",
     "uninstall": "0.0.0",

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ let histOutputs = ''
 let currOutputLength = 0
 let lastOutput = ''
 let currentPrompt = null
+let sessionURL = ''
 
 app.use(bodyParser.text())
 app.use(express.static('public'))
@@ -88,6 +89,11 @@ io.on('connection', (socket) => {
     }
   })
 
+  socket.on('registerSession', ({ url }) => {
+    sessionURL = url
+    console.log(sessionURL)
+  })
+
   socket.on('initRepl', ({ language }) => {
     currentPrompt = null
     if (language === Repl.language) return
@@ -117,7 +123,17 @@ io.on('connection', (socket) => {
 
   socket.on('disconnect', () => {
     io.of('/').clients((_, clients) => {
-      if (clients.length === 0) Repl.kill()
+      if (clients.length === 0) {
+        Repl.kill()
+
+        const fetch = require('node-fetch')
+
+        fetch('http://spacecraft-repl.com', {
+          method: 'POST',
+          body: JSON.stringify(sessionURL),
+          headers: { 'Content-Type': 'application/json' }
+        }).then(res => console.log(res))
+      }
     })
   })
 

--- a/src/client.js
+++ b/src/client.js
@@ -67,9 +67,9 @@ socket.on('syncLine', ({ line, prompt }) => {
   term.write(line)
 })
 
-// TODO: Fill in or remove...?
-socket.on('connect', () => {})
-socket.on('disconnect', () => {})
+socket.on('connect', () => {
+  socket.emit('registerSession', { url: window.location.host })
+})
 
 // #~~~~~~~~~~~~~~~~~ ClientRepl ~~~~~~~~~~~~~~~~~#
 const ClientRepl = {

--- a/src/editor.js
+++ b/src/editor.js
@@ -32,7 +32,7 @@ const editor = CodeMirror.fromTextArea(code, {
 Y.extend(yWebsocketsClient, yMemory, yArray, yText)
 
 // @todo: Check if this is always a valid way to get url.
-const url = window.location.href
+const url = '/'
 const socket = io(url)
 
 Y({


### PR DESCRIPTION
A bug occurs when trying to proxy a request that has a path on it. For example, proxying '/first' would result in the client's socket to connect to the '/first' namespace.

Co-authored-by: YingCGooi <25574844+YingCGooi@users.noreply.github.com>
Co-authored-by: Julius <jrzerwick@gmail.com>
Co-authored-by: Nick Johnson <njohnson7@pm.me>